### PR TITLE
Add support for GET /api/setting API

### DIFF
--- a/oas/components/schemas/setting/model.yml
+++ b/oas/components/schemas/setting/model.yml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  alias_generator:
+    type: string
+  notification:
+    type: boolean
+  random_alias_default_domain:
+    type: string
+  sender_format:
+    type: string
+  random_alias_suffix:
+    type: string

--- a/oas/paths/setting/get.yml
+++ b/oas/paths/setting/get.yml
@@ -1,0 +1,11 @@
+tags:
+  - settings
+summary: Return user setting
+description: Return user setting
+responses:
+  '200':
+    description: Successful
+    content: 
+      application/json:
+        schema:
+          $ref: '@schemas/setting/model.yml'


### PR DESCRIPTION
Add support for the GET /api/setting API.

* Add `oas/components/schemas/setting/model.yml` to define the schema for the user setting response with properties: `alias_generator`, `notification`, `random_alias_default_domain`, `sender_format`, and `random_alias_suffix`.
* Add `oas/paths/setting/get.yml` to define the GET /api/setting endpoint with tags set to `settings`, summary and description set to "Return user setting", and a 200 response referencing the schema `@schemas/setting/model.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KennethWussmann/simplelogin-client/pull/42?shareId=c6f80b1c-d6fa-4760-837e-d8e595033ae2).